### PR TITLE
Variável inativa

### DIFF
--- a/PLAY.sh
+++ b/PLAY.sh
@@ -30,7 +30,7 @@ _show () {
 		OUTGATE=$(echo $SRC | grep -o 'out_gate')
 		LEAVEFIGHT=$(echo $SRC | sed 's/href=/\n/g' | grep '/leaveFight/' | head -n1 | cut -d\' -f2)
 		WDRED=$(echo $SRC | sed "s/alt/\\n/g" | grep 'hp' | head -n1 | cut -d\' -f4) #white/dred
-		PRTCT=$(echo $SRC | grep -io '<b>ueliton</b>')
+#		PRTCT=$(echo $SRC | grep -io '<b>ueliton</b>')
 		HLHP=$(expr $FULL \* $HPER \/ 100)
 		_show
 	}


### PR DESCRIPTION
PRTCT=$(echo $SRC | grep -io '<b>ueliton</b>')
Isso foi uma tentativa de me incluir na troca durante as batalhas. Atualmente nenhuma batalha utiliza essa função, futuramente adicionarei troca por detecção de ID de clã ou de jogador que estiver na lista de amigos(/mail/friends, se isto não atrasar execução) para alianças em batalhas.