### PR TITLE
Calculo do hp para usar esmalte

### DIFF
--- a/PLAY.sh
+++ b/PLAY.sh
@@ -30,7 +30,7 @@ _show () {
 		OUTGATE=$(echo $SRC | grep -o 'out_gate')
 		LEAVEFIGHT=$(echo $SRC | sed 's/href=/\n/g' | grep '/leaveFight/' | head -n1 | cut -d\' -f2)
 		WDRED=$(echo $SRC | sed "s/alt/\\n/g" | grep 'hp' | head -n1 | cut -d\' -f4) #white/dred
-		PRTCT=$(echo $SRC | grep -io '<b>ueliton</b>')
+# HPLP contém o calculo do hp para usar esmalte, o comamdo expr é usado para calcular.
 		HLHP=$(expr $FULL \* $HPER \/ 100)
 		_show
 	}


### PR DESCRIPTION
PLAY.sh
Pode ignorar essa alteração, é que não encontrei outra forma de comentar aqui.
Pra facilitar o ententidimento sobre o calculo do HP,  talvez você consiga encontrar uma solução que não estou conseguindo ver.
Essa é a variável responsavel pelo calculo HP cheio × Porcentagem ÷ 100
O backslash \ é pra contornar as limitações do Shell.
HLHP=$(expr $FULL \* $HPER \/ 100)

$FULL(HP cheio) e $HPER(porcentagem) estão nas funções das batalhas. Comentarei coliseum.sh a seguir por ter mais chances de ser testado...